### PR TITLE
Make apache alias optional

### DIFF
--- a/templates/default/apache.conf.erb
+++ b/templates/default/apache.conf.erb
@@ -3,7 +3,11 @@
     ErrorLog <%= @conf['error_log'] %>
     LogLevel <%= @conf['log_level'] %>
 
+    <% if !@conf['alias'] || @conf['alias'] == '/' -%>
+    DocumentRoot <%= node['kibana']['install_dir'] %>
+    <% else -%>
     Alias <%= @conf['alias'] -%> "<%= node['kibana']['install_dir'] -%>"
+    <% end -%>
     <Directory "<%= node['kibana']['install_dir'] -%>">
         Options Indexes MultiViews FollowSymLinks
         AllowOverride None


### PR DESCRIPTION
Makes is so if `node['kibana']['apache']['alias']` is falsy or '/', to set the document root instead of an alias. 
